### PR TITLE
[SC-1] Remove CreateMiningPoolLog from transaction_log_type

### DIFF
--- a/deploy.sql
+++ b/deploy.sql
@@ -550,15 +550,14 @@ values
 (15, 'StopStakingLog'),
 (16, 'RewardMiningPoolLog'),
 (17, 'NominationLog'),
-(18, 'StartMiningLog'),
+(18, 'MineLog'),
 (19, 'CollectMiningRewardsLog'),
-(20, 'StopMiningLog'),
-(21, 'EnableMiningLog'),
-(22, 'DistributionLog'),
-(23, 'CreateVaultCertificateLog'),
-(24, 'RevokeVaultCertificateLog'),
-(25, 'RedeemVaultCertificateLog'),
-(26, 'ChangeVaultOwnerLog');
+(20, 'EnableMiningLog'),
+(21, 'DistributionLog'),
+(22, 'CreateVaultCertificateLog'),
+(23, 'RevokeVaultCertificateLog'),
+(24, 'RedeemVaultCertificateLog'),
+(25, 'ChangeVaultOwnerLog');
 
 insert into snapshot_type
 values


### PR DESCRIPTION
Part of migrating the Mining pool contract to the opdex-v1-core repo.

No longer a need for this log as it is expected to be done during the deployment of a staking pool. 