### PR TITLE
[PAPI-87] LP Snapshots

### DIFF
--- a/pipeline-scripts/create-database.sql
+++ b/pipeline-scripts/create-database.sql
@@ -274,20 +274,24 @@ CREATE PROCEDURE CreateDatabase ()
 
         CREATE TABLE IF NOT EXISTS pool_liquidity_summary
         (
-            Id               BIGINT UNSIGNED AUTO_INCREMENT,
-            LiquidityPoolId  BIGINT UNSIGNED    NOT NULL,
-            LiquidityUsd     DECIMAL(30, 8)     NOT NULL,
-            VolumeUsd        DECIMAL(30, 8)     NOT NULL,
-            StakingWeight    BIGINT UNSIGNED    NOT NULL,
-            LockedCrs        BIGINT UNSIGNED    NOT NULL,
-            LockedSrc        VARCHAR(78)        NOT NULL,
-            CreatedBlock     BIGINT UNSIGNED    NOT NULL,
-            ModifiedBlock    BIGINT UNSIGNED    NOT NULL,
+            Id                              BIGINT UNSIGNED AUTO_INCREMENT,
+            LiquidityPoolId                 BIGINT UNSIGNED    NOT NULL,
+            LiquidityUsd                    DECIMAL(30, 8)     NOT NULL,
+            DailyLiquidityUsdChangePercent  DECIMAL(30, 8)     NOT NULL,
+            VolumeUsd                       DECIMAL(30, 8)     NOT NULL,
+            StakingWeight                   BIGINT UNSIGNED    NOT NULL,
+            DailyStakingWeightChangePercent DECIMAL(30, 8)     NOT NULL,
+            LockedCrs                       BIGINT UNSIGNED    NOT NULL,
+            LockedSrc                       VARCHAR(78)        NOT NULL,
+            CreatedBlock                    BIGINT UNSIGNED    NOT NULL,
+            ModifiedBlock                   BIGINT UNSIGNED    NOT NULL,
             PRIMARY KEY (Id),
             INDEX pool_liquidity_summary_liquidity_pool_id_ix (LiquidityPoolId),
             INDEX pool_liquidity_summary_liquidity_usd_ix (LiquidityUsd),
+            INDEX pool_liquidity_summary_daily_liquidity_usd_change_ix (DailyLiquidityUsdChangePercent),
             INDEX pool_liquidity_summary_volume_usd_ix (VolumeUsd),
             INDEX pool_liquidity_summary_staking_weight_ix (StakingWeight),
+            INDEX pool_liquidity_summary_daily_staking_weight_change_ix (DailyStakingWeightChangePercent),
             INDEX pool_liquidity_summary_locked_crs_ix (LockedCrs),
             CONSTRAINT pool_liquidity_summary_liquidity_pool_id_pool_liquidity_id_fk
                 FOREIGN KEY (LiquidityPoolId)

--- a/scripts/PAPI-87_LiquidityPoolSnapshots.sql
+++ b/scripts/PAPI-87_LiquidityPoolSnapshots.sql
@@ -4,29 +4,29 @@ DELIMITER //
 
 CREATE PROCEDURE BackFillPoolSnapshotOHLC ()
 BEGIN
-	DECLARE finished INTEGER DEFAULT 0;
-	DECLARE Id bigint unsigned;
+    DECLARE finished INTEGER DEFAULT 0;
+    DECLARE Id bigint unsigned;
     DECLARE Details JSON;
 
-	-- declare cursor
-	DEClARE snapshotCursor
-		CURSOR FOR
-			SELECT * FROM pool_liquidity_snapshot WHERE JSON_EXTRACT(Details, '$.reserves.usd.close') IS NULL;
+    -- declare cursor
+    DEClARE snapshotCursor
+        CURSOR FOR
+            SELECT * FROM pool_liquidity_snapshot WHERE JSON_EXTRACT(Details, '$.reserves.usd.close') IS NULL;
 
-	-- declare NOT FOUND handler
-	DECLARE CONTINUE HANDLER
+    -- declare NOT FOUND handler
+    DECLARE CONTINUE HANDLER
         FOR NOT FOUND SET finished = 1;
 
-	OPEN snapshotCursor;
+    OPEN snapshotCursor;
 
-	getSnapshot: LOOP
-		FETCH snapshotCursor INTO Id, Details;
+    getSnapshot: LOOP
+        FETCH snapshotCursor INTO Id, Details;
 
-		IF finished = 1 THEN
-			LEAVE getSnapshot;
-		END IF;
+        IF finished = 1 THEN
+            LEAVE getSnapshot;
+        END IF;
 
-		-- Build new JSON and update record by Id with new JSON
+        -- Build new JSON and update record by Id with new JSON
         SELECT JSON_MERGE_PRESERVE(
             JSON_OBJECT('cost', JSON_MERGE_PRESERVE(
                 JSON_OBJECT('crsPerSrc', JSON_MERGE_PRESERVE(
@@ -96,9 +96,9 @@ BEGIN
             )),
         ) INTO @UpdatedDetails;
 
-		UPDATE pool_liquidity_snapshot SET Details = @UpdatedDetails WHERE Id = @Id;
-	END LOOP getSnapshot;
-	CLOSE snapshotCursor;
+        UPDATE pool_liquidity_snapshot SET Details = @UpdatedDetails WHERE Id = @Id;
+    END LOOP getSnapshot;
+    CLOSE snapshotCursor;
 
 END //
 

--- a/scripts/PAPI-87_LiquidityPoolSnapshots.sql
+++ b/scripts/PAPI-87_LiquidityPoolSnapshots.sql
@@ -47,7 +47,7 @@ BEGIN
             JSON_OBJECT('volume', JSON_MERGE_PRESERVE(
                                     JSON_OBJECT('crs', JSON_EXTRACT(@Details, '$.volume.crs')),
                                     JSON_OBJECT('src', JSON_EXTRACT(@Details, '$.volume.src')),
-                                    JSON_OBJECT('usd', JSON_EXTRACT(@Details, '$.volume.usd')),
+                                    JSON_OBJECT('usd', JSON_EXTRACT(@Details, '$.volume.usd'))
                                   )
             ),
             JSON_OBJECT('rewards', JSON_MERGE_PRESERVE(
@@ -93,7 +93,7 @@ BEGIN
                                             JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.reserves.usd'))
                                         )
                 )
-            )),
+            ))
         ) INTO @UpdatedDetails;
 
         UPDATE pool_liquidity_snapshot SET Details = @UpdatedDetails WHERE Id = @Id;

--- a/scripts/PAPI-87_LiquidityPoolSnapshots.sql
+++ b/scripts/PAPI-87_LiquidityPoolSnapshots.sql
@@ -1,0 +1,105 @@
+USE platform;
+
+DELIMITER //
+
+CREATE PROCEDURE BackFillPoolSnapshotOHLC ()
+BEGIN
+	DECLARE finished INTEGER DEFAULT 0;
+	DECLARE Id bigint unsigned;
+    DECLARE Details JSON;
+
+	-- declare cursor
+	DEClARE snapshotCursor
+		CURSOR FOR
+			SELECT * FROM pool_liquidity_snapshot WHERE JSON_EXTRACT(Details, '$.reserves.usd.close') IS NULL;
+
+	-- declare NOT FOUND handler
+	DECLARE CONTINUE HANDLER
+        FOR NOT FOUND SET finished = 1;
+
+	OPEN snapshotCursor;
+
+	getSnapshot: LOOP
+		FETCH snapshotCursor INTO Id, Details;
+
+		IF finished = 1 THEN
+			LEAVE getSnapshot;
+		END IF;
+
+		-- Build new JSON and update record by Id with new JSON
+        SELECT JSON_MERGE_PRESERVE(
+            JSON_OBJECT('cost', JSON_MERGE_PRESERVE(
+                JSON_OBJECT('crsPerSrc', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.cost.crsPerSrc.low')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.cost.crsPerSrc.high')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.cost.crsPerSrc.open')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.cost.crsPerSrc.close'))
+                                        )
+                ),
+                JSON_OBJECT('srcPerCrs', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.cost.srcPerCrs.low')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.cost.srcPerCrs.high')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.cost.srcPerCrs.open')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.cost.srcPerCrs.close'))
+                                        )
+                )
+            )),
+            JSON_OBJECT('volume', JSON_MERGE_PRESERVE(
+                                    JSON_OBJECT('crs', JSON_EXTRACT(@Details, '$.volume.crs')),
+                                    JSON_OBJECT('src', JSON_EXTRACT(@Details, '$.volume.src')),
+                                    JSON_OBJECT('usd', JSON_EXTRACT(@Details, '$.volume.usd')),
+                                  )
+            ),
+            JSON_OBJECT('rewards', JSON_MERGE_PRESERVE(
+                                    JSON_OBJECT('marketUsd', JSON_EXTRACT(@Details, '$.rewards.marketUsd')),
+                                    JSON_OBJECT('providerUsd', JSON_EXTRACT(@Details, '$.rewards.providerUsd'))
+                                  )
+            ),
+            JSON_OBJECT('staking', JSON_MERGE_PRESERVE(
+                JSON_OBJECT('usd', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.staking.usd')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.staking.usd')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.staking.usd')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.staking.usd'))
+                                        )
+                ),
+                JSON_OBJECT('weight', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.staking.weight')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.staking.weight')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.staking.weight')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.staking.weight'))
+                                        )
+                )
+            )),
+            JSON_OBJECT('reserves', JSON_MERGE_PRESERVE(
+                JSON_OBJECT('crs', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.reserves.crs')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.reserves.crs')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.reserves.crs')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.reserves.crs'))
+                                        )
+                ),
+                JSON_OBJECT('src', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.reserves.src')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.reserves.src')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.reserves.src')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.reserves.src'))
+                                        )
+                ),
+                JSON_OBJECT('usd', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.reserves.usd')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.reserves.usd')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.reserves.usd')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.reserves.usd'))
+                                        )
+                )
+            )),
+        ) INTO @UpdatedDetails;
+
+		UPDATE pool_liquidity_snapshot SET Details = @UpdatedDetails WHERE Id = @Id;
+	END LOOP getSnapshot;
+	CLOSE snapshotCursor;
+
+END //
+
+DELIMITER ;

--- a/scripts/PAPI-87_LiquidityPoolSnapshots.sql
+++ b/scripts/PAPI-87_LiquidityPoolSnapshots.sql
@@ -2,16 +2,18 @@ USE platform;
 
 DELIMITER //
 
-CREATE PROCEDURE BackFillPoolSnapshotOHLC ()
+DROP PROCEDURE IF EXISTS BackFillPoolSnapshotOHLC; //
+
+CREATE PROCEDURE BackFillPoolSnapshotOHLC()
 BEGIN
     DECLARE finished INTEGER DEFAULT 0;
-    DECLARE Id bigint unsigned;
-    DECLARE Details JSON;
+    DECLARE SnapshotId bigint unsigned;
+    DECLARE SnapshotDetails JSON;
 
     -- declare cursor
     DEClARE snapshotCursor
         CURSOR FOR
-            SELECT * FROM pool_liquidity_snapshot WHERE JSON_EXTRACT(Details, '$.reserves.usd.close') IS NULL;
+            SELECT Id, Details FROM pool_liquidity_snapshot WHERE JSON_EXTRACT(Details, '$.reserves.usd.close') IS NULL;
 
     -- declare NOT FOUND handler
     DECLARE CONTINUE HANDLER
@@ -20,86 +22,88 @@ BEGIN
     OPEN snapshotCursor;
 
     getSnapshot: LOOP
-        FETCH snapshotCursor INTO Id, Details;
+        FETCH snapshotCursor INTO SnapshotId, SnapshotDetails;
 
         IF finished = 1 THEN
             LEAVE getSnapshot;
         END IF;
 
         -- Build new JSON and update record by Id with new JSON
-        SELECT JSON_MERGE_PRESERVE(
+        UPDATE pool_liquidity_snapshot SET Details = (SELECT JSON_MERGE_PRESERVE(
             JSON_OBJECT('cost', JSON_MERGE_PRESERVE(
                 JSON_OBJECT('crsPerSrc', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.cost.crsPerSrc.low')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.cost.crsPerSrc.high')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.cost.crsPerSrc.open')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.cost.crsPerSrc.close'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.cost.crsPerSrc.low')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.cost.crsPerSrc.high')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.cost.crsPerSrc.open')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.cost.crsPerSrc.close'))
                                         )
                 ),
                 JSON_OBJECT('srcPerCrs', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.cost.srcPerCrs.low')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.cost.srcPerCrs.high')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.cost.srcPerCrs.open')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.cost.srcPerCrs.close'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.cost.srcPerCrs.low')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.cost.srcPerCrs.high')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.cost.srcPerCrs.open')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.cost.srcPerCrs.close'))
                                         )
                 )
             )),
             JSON_OBJECT('volume', JSON_MERGE_PRESERVE(
-                                    JSON_OBJECT('crs', JSON_EXTRACT(@Details, '$.volume.crs')),
-                                    JSON_OBJECT('src', JSON_EXTRACT(@Details, '$.volume.src')),
-                                    JSON_OBJECT('usd', JSON_EXTRACT(@Details, '$.volume.usd'))
+                                    JSON_OBJECT('crs', JSON_EXTRACT(SnapshotDetails, '$.volume.crs')),
+                                    JSON_OBJECT('src', JSON_EXTRACT(SnapshotDetails, '$.volume.src')),
+                                    JSON_OBJECT('usd', JSON_EXTRACT(SnapshotDetails, '$.volume.usd'))
                                   )
             ),
             JSON_OBJECT('rewards', JSON_MERGE_PRESERVE(
-                                    JSON_OBJECT('marketUsd', JSON_EXTRACT(@Details, '$.rewards.marketUsd')),
-                                    JSON_OBJECT('providerUsd', JSON_EXTRACT(@Details, '$.rewards.providerUsd'))
+                                    JSON_OBJECT('marketUsd', JSON_EXTRACT(SnapshotDetails, '$.rewards.marketUsd')),
+                                    JSON_OBJECT('providerUsd', JSON_EXTRACT(SnapshotDetails, '$.rewards.providerUsd'))
                                   )
             ),
             JSON_OBJECT('staking', JSON_MERGE_PRESERVE(
                 JSON_OBJECT('usd', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.staking.usd')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.staking.usd')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.staking.usd')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.staking.usd'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.staking.usd')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.staking.usd')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.staking.usd')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.staking.usd'))
                                         )
                 ),
                 JSON_OBJECT('weight', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.staking.weight')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.staking.weight')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.staking.weight')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.staking.weight'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.staking.weight')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.staking.weight')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.staking.weight')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.staking.weight'))
                                         )
                 )
             )),
             JSON_OBJECT('reserves', JSON_MERGE_PRESERVE(
                 JSON_OBJECT('crs', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.reserves.crs')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.reserves.crs')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.reserves.crs')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.reserves.crs'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.reserves.crs')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.reserves.crs')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.reserves.crs')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.reserves.crs'))
                                         )
                 ),
                 JSON_OBJECT('src', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.reserves.src')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.reserves.src')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.reserves.src')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.reserves.src'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.reserves.src')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.reserves.src')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.reserves.src')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.reserves.src'))
                                         )
                 ),
                 JSON_OBJECT('usd', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.reserves.usd')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.reserves.usd')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.reserves.usd')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.reserves.usd'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.reserves.usd')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.reserves.usd')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.reserves.usd')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.reserves.usd'))
                                         )
                 )
             ))
-        ) INTO @UpdatedDetails;
-
-        UPDATE pool_liquidity_snapshot SET Details = @UpdatedDetails WHERE Id = @Id;
+        )) WHERE Id = SnapshotId;
     END LOOP getSnapshot;
     CLOSE snapshotCursor;
 
 END //
+
+CALL BackFillPoolSnapshotOHLC(); //
+
+DROP PROCEDURE BackFillPoolSnapshotOHLC; //
 
 DELIMITER ;

--- a/scripts/PAPI-87_LpSummaryPercentChange.sql
+++ b/scripts/PAPI-87_LpSummaryPercentChange.sql
@@ -1,0 +1,45 @@
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS InsertPercentChange; //
+
+CREATE PROCEDURE InsertPercentChange()
+ BEGIN
+    SELECT COUNT(*) into @exists
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA='platform'
+        AND TABLE_NAME='pool_liquidity_summary'
+        AND column_name='DailyLiquidityUsdChangePercent';
+
+    IF @exists = 0 THEN
+        ALTER TABLE pool_liquidity_summary ADD COLUMN DailyLiquidityUsdChangePercent DECIMAL(30,8) NULL AFTER LiquidityUsd;
+
+        UPDATE pool_liquidity_summary SET DailyLiquidityUsdChangePercent = 0;
+
+        ALTER TABLE pool_liquidity_summary MODIFY DailyLiquidityUsdChangePercent DECIMAL(30,8) NOT NULL;
+        ALTER TABLE pool_liquidity_summary ADD INDEX pool_liquidity_summary_daily_liquidity_usd_change_ix (DailyLiquidityUsdChangePercent);
+    END IF;
+
+    SELECT COUNT(*) into @exists
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA='platform'
+        AND TABLE_NAME='pool_liquidity_summary'
+        AND column_name='DailyStakingWeightChangePercent';
+
+    IF @exists = 0 THEN
+        ALTER TABLE pool_liquidity_summary ADD COLUMN DailyStakingWeightChangePercent DECIMAL(30,8) NULL AFTER StakingWeight;
+
+        UPDATE pool_liquidity_summary SET DailyStakingWeightChangePercent = 0;
+
+        ALTER TABLE pool_liquidity_summary MODIFY DailyStakingWeightChangePercent DECIMAL(30,8) NOT NULL;
+        ALTER TABLE pool_liquidity_summary ADD INDEX pool_liquidity_summary_daily_staking_weight_change_ix (DailyStakingWeightChangePercent);
+    END IF;
+ END;
+//
+
+CALL InsertPercentChange();
+//
+
+DROP PROCEDURE InsertPercentChange;
+//
+
+DELIMITER ;

--- a/scripts/PAPI-87_MarketSnapshots.sql
+++ b/scripts/PAPI-87_MarketSnapshots.sql
@@ -30,7 +30,7 @@ BEGIN
 
         -- Build new JSON and update record by Id with new JSON
         UPDATE market_snapshot SET Details = (SELECT JSON_MERGE_PRESERVE(
-            JSON_OBJECT('volume', JSON_EXTRACT(SnapshotDetails, '$.volume')),
+            JSON_OBJECT('volumeUsd', JSON_EXTRACT(SnapshotDetails, '$.volume')),
             JSON_OBJECT('rewards', JSON_MERGE_PRESERVE(
                                     JSON_OBJECT('marketUsd', JSON_EXTRACT(SnapshotDetails, '$.rewards.marketUsd')),
                                     JSON_OBJECT('providerUsd', JSON_EXTRACT(SnapshotDetails, '$.rewards.providerUsd'))

--- a/scripts/PAPI-87_MarketSnapshots.sql
+++ b/scripts/PAPI-87_MarketSnapshots.sql
@@ -2,16 +2,18 @@ USE platform;
 
 DELIMITER //
 
-CREATE PROCEDURE BackFillPoolSnapshotOHLC ()
+DROP PROCEDURE IF EXISTS BackFillMarketSnapshotOHLC; //
+
+CREATE PROCEDURE BackFillMarketSnapshotOHLC()
 BEGIN
     DECLARE finished INTEGER DEFAULT 0;
-    DECLARE Id bigint unsigned;
-    DECLARE Details JSON;
+    DECLARE SnapshotId bigint unsigned;
+    DECLARE SnapshotDetails JSON;
 
     -- declare cursor
     DEClARE snapshotCursor
         CURSOR FOR
-            SELECT * FROM market_snapshot WHERE JSON_EXTRACT(Details, '$.liquidityUsd.close') IS NULL;
+            SELECT Id, Details FROM market_snapshot WHERE JSON_EXTRACT(Details, '$.liquidityUsd.close') IS NULL;
 
     -- declare NOT FOUND handler
     DECLARE CONTINUE HANDLER
@@ -20,48 +22,50 @@ BEGIN
     OPEN snapshotCursor;
 
     getSnapshot: LOOP
-        FETCH snapshotCursor INTO Id, Details;
+        FETCH snapshotCursor INTO SnapshotId, SnapshotDetails;
 
         IF finished = 1 THEN
             LEAVE getSnapshot;
         END IF;
 
         -- Build new JSON and update record by Id with new JSON
-        SELECT JSON_MERGE_PRESERVE(
-            JSON_OBJECT('volume', JSON_EXTRACT(@Details, '$.volume')),
+        UPDATE market_snapshot SET Details = (SELECT JSON_MERGE_PRESERVE(
+            JSON_OBJECT('volume', JSON_EXTRACT(SnapshotDetails, '$.volume')),
             JSON_OBJECT('rewards', JSON_MERGE_PRESERVE(
-                                    JSON_OBJECT('marketUsd', JSON_EXTRACT(@Details, '$.rewards.marketUsd')),
-                                    JSON_OBJECT('providerUsd', JSON_EXTRACT(@Details, '$.rewards.providerUsd'))
+                                    JSON_OBJECT('marketUsd', JSON_EXTRACT(SnapshotDetails, '$.rewards.marketUsd')),
+                                    JSON_OBJECT('providerUsd', JSON_EXTRACT(SnapshotDetails, '$.rewards.providerUsd'))
                                   )
             ),
             JSON_OBJECT('staking', JSON_MERGE_PRESERVE(
                 JSON_OBJECT('usd', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.staking.usd')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.staking.usd')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.staking.usd')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.staking.usd'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.staking.usd')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.staking.usd')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.staking.usd')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.staking.usd'))
                                         )
                 ),
                 JSON_OBJECT('weight', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.staking.weight')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.staking.weight')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.staking.weight')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.staking.weight'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.staking.weight')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.staking.weight')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.staking.weight')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.staking.weight'))
                                         )
                 )
             )),
             JSON_OBJECT('liquidityUsd', JSON_MERGE_PRESERVE(
-                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.liquidity')),
-                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.liquidity')),
-                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.liquidity')),
-                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.liquidity'))
+                                            JSON_OBJECT('low', JSON_EXTRACT(SnapshotDetails, '$.liquidity')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(SnapshotDetails, '$.liquidity')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(SnapshotDetails, '$.liquidity')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(SnapshotDetails, '$.liquidity'))
                                         ))
-        ) INTO @UpdatedDetails;
-
-        UPDATE market_snapshot SET Details = @UpdatedDetails WHERE Id = @Id;
+        )) WHERE Id = SnapshotId;
     END LOOP getSnapshot;
     CLOSE snapshotCursor;
 
 END //
+
+CALL BackFillMarketSnapshotOHLC(); //
+
+DROP PROCEDURE BackFillMarketSnapshotOHLC; //
 
 DELIMITER ;

--- a/scripts/PAPI-87_MarketSnapshots.sql
+++ b/scripts/PAPI-87_MarketSnapshots.sql
@@ -1,0 +1,67 @@
+USE platform;
+
+DELIMITER //
+
+CREATE PROCEDURE BackFillPoolSnapshotOHLC ()
+BEGIN
+    DECLARE finished INTEGER DEFAULT 0;
+    DECLARE Id bigint unsigned;
+    DECLARE Details JSON;
+
+    -- declare cursor
+    DEClARE snapshotCursor
+        CURSOR FOR
+            SELECT * FROM market_snapshot WHERE JSON_EXTRACT(Details, '$.liquidityUsd.close') IS NULL;
+
+    -- declare NOT FOUND handler
+    DECLARE CONTINUE HANDLER
+        FOR NOT FOUND SET finished = 1;
+
+    OPEN snapshotCursor;
+
+    getSnapshot: LOOP
+        FETCH snapshotCursor INTO Id, Details;
+
+        IF finished = 1 THEN
+            LEAVE getSnapshot;
+        END IF;
+
+        -- Build new JSON and update record by Id with new JSON
+        SELECT JSON_MERGE_PRESERVE(
+            JSON_OBJECT('volume', JSON_EXTRACT(@Details, '$.volume')),
+            JSON_OBJECT('rewards', JSON_MERGE_PRESERVE(
+                                    JSON_OBJECT('marketUsd', JSON_EXTRACT(@Details, '$.rewards.marketUsd')),
+                                    JSON_OBJECT('providerUsd', JSON_EXTRACT(@Details, '$.rewards.providerUsd'))
+                                  )
+            ),
+            JSON_OBJECT('staking', JSON_MERGE_PRESERVE(
+                JSON_OBJECT('usd', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.staking.usd')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.staking.usd')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.staking.usd')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.staking.usd'))
+                                        )
+                ),
+                JSON_OBJECT('weight', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.staking.weight')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.staking.weight')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.staking.weight')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.staking.weight'))
+                                        )
+                )
+            )),
+            JSON_OBJECT('liquidityUsd', JSON_MERGE_PRESERVE(
+                                            JSON_OBJECT('low', JSON_EXTRACT(@Details, '$.liquidity')),
+                                            JSON_OBJECT('high', JSON_EXTRACT(@Details, '$.liquidity')),
+                                            JSON_OBJECT('open', JSON_EXTRACT(@Details, '$.liquidity')),
+                                            JSON_OBJECT('close', JSON_EXTRACT(@Details, '$.liquidity'))
+                                        ))
+        ) INTO @UpdatedDetails;
+
+        UPDATE market_snapshot SET Details = @UpdatedDetails WHERE Id = @Id;
+    END LOOP getSnapshot;
+    CLOSE snapshotCursor;
+
+END //
+
+DELIMITER ;


### PR DESCRIPTION
Refactors existing `market_snapshot` and `pool_liquidity_snapshot` to include more OHLC data and backfills existing snapshot's values. 

Relates to: https://github.com/Opdex/opdex-v1-api/pull/111